### PR TITLE
fixed resource leak in sequence querying

### DIFF
--- a/src/main/java/org/polyjdbc/core/key/SequenceAllocation.java
+++ b/src/main/java/org/polyjdbc/core/key/SequenceAllocation.java
@@ -67,13 +67,13 @@ public class SequenceAllocation implements KeyGenerator {
     }
 
     private long fetchSequenceValue(String sequenceName, Transaction transaction) throws SQLException {
-        PreparedStatement statement = transaction.prepareStatement(dialect.nextFromSequence(sequenceName));
-
-        ResultSet resultSet = statement.executeQuery();
-        transaction.registerCursor(resultSet);
-
-        resultSet.next();
-        return resultSet.getLong(1);
+        try(PreparedStatement statement = transaction.prepareStatement(dialect.nextFromSequence(sequenceName));
+            ResultSet resultSet = statement.executeQuery())
+        {
+            transaction.registerCursor(resultSet);
+            resultSet.next();
+            return resultSet.getLong(1);
+        }
     }
 
     @Override


### PR DESCRIPTION
when a ResultSet is not properly closed, Oracle throws ORA-01000: maximum open cursors exceeded