### PR TITLE
Add schema name support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ branches:
   only:
     - master
     - development
+    - 20
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ branches:
     - master
     - development
     - 20
+    
 
 env:
   global:

--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,10 @@ task wrapper(type: Wrapper) {
 test {
     useTestNG()
 
+    options {
+        suiteXmlFiles = [ project.file('src/test/resources/testng.xml') ]
+    }
+
     if(project.hasProperty('integration')) {
         options {
             suiteXmlFiles = [ project.file('src/test/resources/testng.xml'), project.file('src/test/resources/testng-integration.xml') ]

--- a/src/main/java/org/polyjdbc/core/DefaultPolyJDBC.java
+++ b/src/main/java/org/polyjdbc/core/DefaultPolyJDBC.java
@@ -38,8 +38,7 @@ public class DefaultPolyJDBC implements PolyJDBC {
         this.schemaManagerFactory = new SchemaManagerFactory(transactionManager, schemaName());
     }
 
-    public String schemaName()
-    {
+    public String schemaName() {
         return schemaName;
     }
 

--- a/src/main/java/org/polyjdbc/core/DefaultPolyJDBC.java
+++ b/src/main/java/org/polyjdbc/core/DefaultPolyJDBC.java
@@ -26,13 +26,21 @@ public class DefaultPolyJDBC implements PolyJDBC {
 
     private final SchemaManagerFactory schemaManagerFactory;
 
-    DefaultPolyJDBC(Dialect dialect, ColumnTypeMapper typeMapper, TransactionManager transactionManager) {
+    private final String schemaName;
+
+    DefaultPolyJDBC(Dialect dialect, String schemaName, ColumnTypeMapper typeMapper, TransactionManager transactionManager) {
         this.dialect = dialect;
+        this.schemaName = schemaName;
         this.queryFactory = new QueryFactory(dialect, typeMapper);
         this.queryRunnerFactory = new QueryRunnerFactory(transactionManager, KeyGeneratorFactory.create(dialect));
         this.simpleQueryRunner = new SimpleQueryRunner(queryRunnerFactory);
         this.transactionRunner = new TransactionRunner(queryRunnerFactory);
-        this.schemaManagerFactory = new SchemaManagerFactory(transactionManager);
+        this.schemaManagerFactory = new SchemaManagerFactory(transactionManager, schemaName());
+    }
+
+    public String schemaName()
+    {
+        return schemaName;
     }
 
     public Dialect dialect() {
@@ -70,4 +78,5 @@ public class DefaultPolyJDBC implements PolyJDBC {
     public void close(Closeable... toClose) {
         TheCloser.close(toClose);
     }
+
 }

--- a/src/main/java/org/polyjdbc/core/PolyJDBC.java
+++ b/src/main/java/org/polyjdbc/core/PolyJDBC.java
@@ -27,6 +27,8 @@ import java.io.Closeable;
 
 public interface PolyJDBC {
 
+    String schemaName();
+
     Dialect dialect();
 
     QueryFactory query();

--- a/src/main/java/org/polyjdbc/core/PolyJDBCBuilder.java
+++ b/src/main/java/org/polyjdbc/core/PolyJDBCBuilder.java
@@ -16,6 +16,8 @@ public final class PolyJDBCBuilder {
 
     private final Dialect dialect;
 
+    private String schemaName;
+
     private final Map<Class<?>, SqlType> customMappings = new HashMap<Class<?>, SqlType>();
     
     private DataSource dataSource;
@@ -23,7 +25,12 @@ public final class PolyJDBCBuilder {
     private ConnectionProvider connectionProvider;
 
     private PolyJDBCBuilder(Dialect dialect) {
+        this(dialect, null);
+    }
+
+    private PolyJDBCBuilder(Dialect dialect, String schemaName) {
         this.dialect = dialect;
+        this.schemaName = schemaName;
     }
 
     /**
@@ -31,6 +38,13 @@ public final class PolyJDBCBuilder {
      */
     public static PolyJDBCBuilder polyJDBC(Dialect dialect) {
         return new PolyJDBCBuilder(dialect);
+    }
+
+    /**
+     * Create new PolyJDBC instance with a given dialect and schema.
+     */
+    public static PolyJDBCBuilder polyJDBC(Dialect dialect, String schemaName) {
+        return new PolyJDBCBuilder(dialect, schemaName);
     }
 
     /**
@@ -43,7 +57,7 @@ public final class PolyJDBCBuilder {
         } else {
             manager = new ExternalTransactionManager(connectionProvider);
         }
-        return new DefaultPolyJDBC(dialect, new ColumnTypeMapper(customMappings), manager);
+        return new DefaultPolyJDBC(dialect, schemaName, new ColumnTypeMapper(customMappings), manager);
     }
 
     /**

--- a/src/main/java/org/polyjdbc/core/schema/SchemaInspectorImpl.java
+++ b/src/main/java/org/polyjdbc/core/schema/SchemaInspectorImpl.java
@@ -34,16 +34,25 @@ class SchemaInspectorImpl implements SchemaInspector {
 
     private String catalog;
 
-    private String schema;
+    private String schemaName;
 
     SchemaInspectorImpl(Transaction transaction) {
         this(transaction, Locale.ENGLISH);
-        extractMetadata(transaction);
     }
 
     SchemaInspectorImpl(Transaction transaction, Locale locale) {
+        this(transaction, locale, null);
+    }
+
+    SchemaInspectorImpl(Transaction transaction, String schemaName) {
+        this(transaction, Locale.ENGLISH, schemaName);
+    }
+
+    SchemaInspectorImpl(Transaction transaction, Locale locale, String schemaName) {
         this.transaction = transaction;
         this.locale = locale;
+        this.schemaName = schemaName;
+        extractMetadata(transaction);
     }
 
     private void extractMetadata(Transaction transaction) {
@@ -59,7 +68,7 @@ class SchemaInspectorImpl implements SchemaInspector {
     @Override
     public boolean relationExists(String name) {
         try {
-            ResultSet resultSet = metadata.getTables(catalog, schema, convertCase(name), new String[]{"TABLE"});
+            ResultSet resultSet = metadata.getTables(catalog, schemaName, convertCase(name), new String[]{"TABLE"});
             transaction.registerCursor(resultSet);
 
             return resultSet.next();
@@ -71,7 +80,7 @@ class SchemaInspectorImpl implements SchemaInspector {
     @Override
     public boolean indexExists(String relationName, String indexName) {
         try {
-            ResultSet resultSet = metadata.getIndexInfo(catalog, schema, convertCase(relationName), false, true);
+            ResultSet resultSet = metadata.getIndexInfo(catalog, schemaName, convertCase(relationName), false, true);
             transaction.registerCursor(resultSet);
 
             String normalizedIndexName = convertCase(indexName);

--- a/src/main/java/org/polyjdbc/core/schema/SchemaManagerFactory.java
+++ b/src/main/java/org/polyjdbc/core/schema/SchemaManagerFactory.java
@@ -25,15 +25,22 @@ public class SchemaManagerFactory {
 
     private final TransactionManager transactionManager;
 
-    public SchemaManagerFactory(TransactionManager transactionManager) {
+    private String schemaName;
+
+    public SchemaManagerFactory(TransactionManager transactionManager, String schemaName) {
         this.transactionManager = transactionManager;
+        if ((schemaName == null) || (schemaName.isEmpty())) {
+            this.schemaName = null;
+        } else {
+            this.schemaName = schemaName;
+        }
     }
 
     public SchemaInspector createInspector() {
-        return new SchemaInspectorImpl(transactionManager.openTransaction());
+        return new SchemaInspectorImpl(transactionManager.openTransaction(), schemaName);
     }
 
     public SchemaManager createManager() {
-        return new SchemaManagerImpl(transactionManager.openTransaction());
+        return new SchemaManagerImpl(transactionManager.openTransaction(), schemaName);
     }
 }

--- a/src/main/java/org/polyjdbc/core/schema/SchemaManagerFactory.java
+++ b/src/main/java/org/polyjdbc/core/schema/SchemaManagerFactory.java
@@ -29,7 +29,7 @@ public class SchemaManagerFactory {
 
     public SchemaManagerFactory(TransactionManager transactionManager, String schemaName) {
         this.transactionManager = transactionManager;
-        if ((schemaName == null) || (schemaName.isEmpty())) {
+        if (schemaName == null || schemaName.isEmpty()) {
             this.schemaName = null;
         } else {
             this.schemaName = schemaName;
@@ -41,6 +41,6 @@ public class SchemaManagerFactory {
     }
 
     public SchemaManager createManager() {
-        return new SchemaManagerImpl(transactionManager.openTransaction(), schemaName);
+        return new SchemaManagerImpl(transactionManager.openTransaction());
     }
 }

--- a/src/main/java/org/polyjdbc/core/schema/SchemaManagerImpl.java
+++ b/src/main/java/org/polyjdbc/core/schema/SchemaManagerImpl.java
@@ -32,17 +32,10 @@ class SchemaManagerImpl implements SchemaManager {
 
     private static final Logger logger = LoggerFactory.getLogger(SchemaManagerImpl.class);
 
-    private String schemaName;
-
     private final Transaction transaction;
 
     SchemaManagerImpl(Transaction transaction) {
-        this(transaction, null);
-    }
-
-    SchemaManagerImpl(Transaction transaction, String schemaName) {
         this.transaction = transaction;
-        this.schemaName = schemaName;
     }
 
     @Override

--- a/src/main/java/org/polyjdbc/core/schema/SchemaManagerImpl.java
+++ b/src/main/java/org/polyjdbc/core/schema/SchemaManagerImpl.java
@@ -32,10 +32,17 @@ class SchemaManagerImpl implements SchemaManager {
 
     private static final Logger logger = LoggerFactory.getLogger(SchemaManagerImpl.class);
 
+    private String schemaName;
+
     private final Transaction transaction;
 
     SchemaManagerImpl(Transaction transaction) {
+        this(transaction, null);
+    }
+
+    SchemaManagerImpl(Transaction transaction, String schemaName) {
         this.transaction = transaction;
+        this.schemaName = schemaName;
     }
 
     @Override

--- a/src/main/java/org/polyjdbc/core/schema/model/Index.java
+++ b/src/main/java/org/polyjdbc/core/schema/model/Index.java
@@ -44,8 +44,7 @@ public class Index implements SchemaEntity {
     Index(Dialect dialect, String name, String schemaName) {
         this.dialect = dialect;
         this.name = name;
-        if ((schemaName == null) || (schemaName.isEmpty()))
-        {
+        if ((schemaName == null) || (schemaName.isEmpty())) {
             this.schemaNameWithSeperator = "";
         } else {
             this.schemaNameWithSeperator = schemaName + ".";

--- a/src/main/java/org/polyjdbc/core/schema/model/Index.java
+++ b/src/main/java/org/polyjdbc/core/schema/model/Index.java
@@ -35,9 +35,21 @@ public class Index implements SchemaEntity {
 
     private String[] targetAttributes;
 
+    private String schemaNameWithSeperator;
+
     Index(Dialect dialect, String name) {
+        this(dialect, name, "");
+    }
+
+    Index(Dialect dialect, String name, String schemaName) {
         this.dialect = dialect;
         this.name = name;
+        if ((schemaName == null) || (schemaName.isEmpty()))
+        {
+            this.schemaNameWithSeperator = "";
+        } else {
+            this.schemaNameWithSeperator = schemaName + ".";
+        }
     }
     
     @Override
@@ -53,14 +65,14 @@ public class Index implements SchemaEntity {
     @Override
     public String ddl() {
         StringBuilder builder = new StringBuilder(DDL_LENGTH);
-        builder.append("CREATE INDEX ").append(name).append(" ON ").append(targetRelation).append("(")
+        builder.append("CREATE INDEX ").append(name).append(" ON ").append(schemaNameWithSeperator).append(targetRelation).append("(")
                 .append(StringUtils.concatenate(",", (Object[]) targetAttributes)).append(")");
         return builder.toString();
     }
 
     @Override
     public String dropDDL() {
-        return dialect.constraints().dropIndex(name, targetRelation);
+        return dialect.constraints().dropIndex(name, schemaNameWithSeperator+targetRelation);
     }
 
     public String getTargetRelation() {

--- a/src/main/java/org/polyjdbc/core/schema/model/Index.java
+++ b/src/main/java/org/polyjdbc/core/schema/model/Index.java
@@ -35,7 +35,7 @@ public class Index implements SchemaEntity {
 
     private String[] targetAttributes;
 
-    private String schemaNameWithSeperator;
+    private String schemaNameWithSeparator;
 
     Index(Dialect dialect, String name) {
         this(dialect, name, "");
@@ -45,9 +45,9 @@ public class Index implements SchemaEntity {
         this.dialect = dialect;
         this.name = name;
         if ((schemaName == null) || (schemaName.isEmpty())) {
-            this.schemaNameWithSeperator = "";
+            this.schemaNameWithSeparator = "";
         } else {
-            this.schemaNameWithSeperator = schemaName + ".";
+            this.schemaNameWithSeparator = schemaName + ".";
         }
     }
     
@@ -64,14 +64,14 @@ public class Index implements SchemaEntity {
     @Override
     public String ddl() {
         StringBuilder builder = new StringBuilder(DDL_LENGTH);
-        builder.append("CREATE INDEX ").append(name).append(" ON ").append(schemaNameWithSeperator).append(targetRelation).append("(")
+        builder.append("CREATE INDEX ").append(name).append(" ON ").append(schemaNameWithSeparator).append(targetRelation).append("(")
                 .append(StringUtils.concatenate(",", (Object[]) targetAttributes)).append(")");
         return builder.toString();
     }
 
     @Override
     public String dropDDL() {
-        return dialect.constraints().dropIndex(name, schemaNameWithSeperator+targetRelation);
+        return dialect.constraints().dropIndex(name, schemaNameWithSeparator+targetRelation);
     }
 
     public String getTargetRelation() {

--- a/src/main/java/org/polyjdbc/core/schema/model/IndexBuilder.java
+++ b/src/main/java/org/polyjdbc/core/schema/model/IndexBuilder.java
@@ -36,12 +36,29 @@ public final class IndexBuilder {
         this.schema = schema;
     }
 
+    private IndexBuilder(Dialect dialect, String name, String schemaName) {
+        this.index = new Index(dialect, name, schemaName);
+    }
+
+    private IndexBuilder(Schema schema, String name, String schemaName) {
+        this(schema.getDialect(), name, schemaName);
+        this.schema = schema;
+    }
+
     public static IndexBuilder index(Dialect dialect, String name) {
         return new IndexBuilder(dialect, name);
     }
 
     public static IndexBuilder index(Schema schema, String name) {
         return new IndexBuilder(schema, name);
+    }
+
+    public static IndexBuilder index(Dialect dialect, String name, String schemaName) {
+        return new IndexBuilder(dialect, name, schemaName);
+    }
+
+    public static IndexBuilder index(Schema schema, String name, String schemaName) {
+        return new IndexBuilder(schema, name, schemaName);
     }
 
     public Index build() {

--- a/src/main/java/org/polyjdbc/core/schema/model/Relation.java
+++ b/src/main/java/org/polyjdbc/core/schema/model/Relation.java
@@ -35,7 +35,7 @@ public class Relation implements SchemaEntity {
 
     private Heading heading;
 
-    private String schemaNameWithSeperator;
+    private String schemaNameWithSeparator;
 
     private Collection<Constraint> constraints = new LinkedList<Constraint>();
 
@@ -47,9 +47,9 @@ public class Relation implements SchemaEntity {
         this.dialect = dialect;
         this.name = name;
         if ((schemaName == null) || (schemaName.isEmpty())) {
-            this.schemaNameWithSeperator = "";
+            this.schemaNameWithSeparator = "";
         } else {
-            this.schemaNameWithSeperator = schemaName + ".";
+            this.schemaNameWithSeparator = schemaName + ".";
         }
     }
 
@@ -64,7 +64,7 @@ public class Relation implements SchemaEntity {
         String constraintsDDL = StringUtils.concatenate(",\n", constraints.toArray());
         StringBuilder builder = new StringBuilder(TO_STRING_LENGTH_BASE + headingDDL.length() + constraintsDDL.length());
 
-        builder.append("CREATE TABLE ").append(schemaNameWithSeperator+name).append(" (\n")
+        builder.append("CREATE TABLE ").append(schemaNameWithSeparator+name).append(" (\n")
                 .append(headingDDL);
         if (constraintsDDL.length() > 0) {
             builder.append(",\n");
@@ -77,7 +77,7 @@ public class Relation implements SchemaEntity {
 
     @Override
     public String dropDDL() {
-        return "DROP TABLE " + schemaNameWithSeperator+name;
+        return "DROP TABLE " + schemaNameWithSeparator+name;
     }
 
     public Dialect getDialect() {

--- a/src/main/java/org/polyjdbc/core/schema/model/Relation.java
+++ b/src/main/java/org/polyjdbc/core/schema/model/Relation.java
@@ -35,11 +35,23 @@ public class Relation implements SchemaEntity {
 
     private Heading heading;
 
+    private String schemaNameWithSeperator;
+
     private Collection<Constraint> constraints = new LinkedList<Constraint>();
 
     Relation(Dialect dialect, String name) {
+        this(dialect, name, "");
+    }
+
+    Relation(Dialect dialect, String name, String schemaName) {
         this.dialect = dialect;
         this.name = name;
+        if ((schemaName == null) || (schemaName.isEmpty()))
+        {
+            this.schemaNameWithSeperator = "";
+        } else {
+            this.schemaNameWithSeperator = schemaName + ".";
+        }
     }
 
     @Override
@@ -53,7 +65,7 @@ public class Relation implements SchemaEntity {
         String constraintsDDL = StringUtils.concatenate(",\n", constraints.toArray());
         StringBuilder builder = new StringBuilder(TO_STRING_LENGTH_BASE + headingDDL.length() + constraintsDDL.length());
 
-        builder.append("CREATE TABLE ").append(name).append(" (\n")
+        builder.append("CREATE TABLE ").append(schemaNameWithSeperator+name).append(" (\n")
                 .append(headingDDL);
         if (constraintsDDL.length() > 0) {
             builder.append(",\n");
@@ -66,7 +78,7 @@ public class Relation implements SchemaEntity {
 
     @Override
     public String dropDDL() {
-        return "DROP TABLE " + name;
+        return "DROP TABLE " + schemaNameWithSeperator+name;
     }
 
     public Dialect getDialect() {

--- a/src/main/java/org/polyjdbc/core/schema/model/Relation.java
+++ b/src/main/java/org/polyjdbc/core/schema/model/Relation.java
@@ -46,8 +46,7 @@ public class Relation implements SchemaEntity {
     Relation(Dialect dialect, String name, String schemaName) {
         this.dialect = dialect;
         this.name = name;
-        if ((schemaName == null) || (schemaName.isEmpty()))
-        {
+        if ((schemaName == null) || (schemaName.isEmpty())) {
             this.schemaNameWithSeperator = "";
         } else {
             this.schemaNameWithSeperator = schemaName + ".";

--- a/src/main/java/org/polyjdbc/core/schema/model/RelationBuilder.java
+++ b/src/main/java/org/polyjdbc/core/schema/model/RelationBuilder.java
@@ -39,8 +39,19 @@ public final class RelationBuilder {
         heading = new Heading(dialect);
     }
 
+    private RelationBuilder(Dialect dialect, String name, String schemaName) {
+        this.dialect = dialect;
+        relation = new Relation(dialect, name, schemaName);
+        heading = new Heading(dialect);
+    }
+
     private RelationBuilder(Schema schema, String name) {
         this(schema.getDialect(), name);
+        this.schema = schema;
+    }
+
+    private RelationBuilder(Schema schema, String name, String schemaName) {
+        this(schema.getDialect(), name, schemaName);
         this.schema = schema;
     }
 
@@ -50,6 +61,14 @@ public final class RelationBuilder {
 
     public static RelationBuilder relation(Schema schema, String name) {
         return new RelationBuilder(schema, name);
+    }
+
+    public static RelationBuilder relation(Dialect dialect, String name, String schemaName) {
+        return new RelationBuilder(dialect, name, schemaName);
+    }
+
+    public static RelationBuilder relation(Schema schema, String name, String schemaName) {
+        return new RelationBuilder(schema, name, schemaName);
     }
 
     public Relation build() {

--- a/src/main/java/org/polyjdbc/core/schema/model/Schema.java
+++ b/src/main/java/org/polyjdbc/core/schema/model/Schema.java
@@ -64,24 +64,15 @@ public final class Schema {
     }
 
     public RelationBuilder addRelation(String name) {
-        if ((schemaName == null) || (schemaName.isEmpty()))
-            return RelationBuilder.relation(this, name);
-        else
-            return RelationBuilder.relation(this, name, getSchemaName());
+        return RelationBuilder.relation(this, name, getSchemaName());
     }
 
     public IndexBuilder addIndex(String name) {
-        if ((schemaName == null) || (schemaName.isEmpty()))
-            return IndexBuilder.index(this, name);
-        else
-            return IndexBuilder.index(this, name, getSchemaName());
+        return IndexBuilder.index(this, name, getSchemaName());
     }
 
     public SequenceBuilder addSequence(String name) {
-        if ((schemaName == null) || (schemaName.isEmpty()))
-            return SequenceBuilder.sequence(this, name);
-        else
-            return SequenceBuilder.sequence(this, name, getSchemaName());
+        return SequenceBuilder.sequence(this, name, getSchemaName());
     }
 
     public String getSchemaName() {

--- a/src/main/java/org/polyjdbc/core/schema/model/Schema.java
+++ b/src/main/java/org/polyjdbc/core/schema/model/Schema.java
@@ -84,13 +84,11 @@ public final class Schema {
             return SequenceBuilder.sequence(this, name, getSchemaName());
     }
 
-    public String getSchemaName()
-    {
+    public String getSchemaName() {
         return schemaName;
     }
 
-    public void setSchemaName(String schemaName)
-    {
+    public void setSchemaName(String schemaName) {
         this.schemaName = schemaName;
     }
 }

--- a/src/main/java/org/polyjdbc/core/schema/model/Schema.java
+++ b/src/main/java/org/polyjdbc/core/schema/model/Schema.java
@@ -32,8 +32,15 @@ public final class Schema {
 
     private final List<Sequence> sequences = new ArrayList<Sequence>();
 
+    private String schemaName;
+
     public Schema(Dialect dialect) {
+        this(dialect, null);
+    }
+
+    public Schema(Dialect dialect, String schemaName) {
         this.dialect = dialect;
+        this.schemaName = schemaName;
     }
 
     public Dialect getDialect() {
@@ -57,14 +64,33 @@ public final class Schema {
     }
 
     public RelationBuilder addRelation(String name) {
-        return RelationBuilder.relation(this, name);
+        if ((schemaName == null) || (schemaName.isEmpty()))
+            return RelationBuilder.relation(this, name);
+        else
+            return RelationBuilder.relation(this, name, getSchemaName());
     }
 
     public IndexBuilder addIndex(String name) {
-        return IndexBuilder.index(this, name);
+        if ((schemaName == null) || (schemaName.isEmpty()))
+            return IndexBuilder.index(this, name);
+        else
+            return IndexBuilder.index(this, name, getSchemaName());
     }
 
     public SequenceBuilder addSequence(String name) {
-        return SequenceBuilder.sequence(this, name);
+        if ((schemaName == null) || (schemaName.isEmpty()))
+            return SequenceBuilder.sequence(this, name);
+        else
+            return SequenceBuilder.sequence(this, name, getSchemaName());
+    }
+
+    public String getSchemaName()
+    {
+        return schemaName;
+    }
+
+    public void setSchemaName(String schemaName)
+    {
+        this.schemaName = schemaName;
     }
 }

--- a/src/main/java/org/polyjdbc/core/schema/model/Sequence.java
+++ b/src/main/java/org/polyjdbc/core/schema/model/Sequence.java
@@ -36,8 +36,7 @@ public class Sequence implements SchemaEntity {
     public Sequence(Dialect dialect, String name, String schemaName) {
         this.name = name;
         this.dialect = dialect;
-        if ((schemaName == null) || (schemaName.isEmpty()))
-        {
+        if ((schemaName == null) || (schemaName.isEmpty())) {
             this.schemaNameWithSeperator = "";
         } else {
             this.schemaNameWithSeperator = schemaName + ".";

--- a/src/main/java/org/polyjdbc/core/schema/model/Sequence.java
+++ b/src/main/java/org/polyjdbc/core/schema/model/Sequence.java
@@ -27,9 +27,21 @@ public class Sequence implements SchemaEntity {
 
     private final Dialect dialect;
 
+    private String schemaNameWithSeperator;
+
     public Sequence(Dialect dialect, String name) {
+        this(dialect, name, "");
+    }
+
+    public Sequence(Dialect dialect, String name, String schemaName) {
         this.name = name;
         this.dialect = dialect;
+        if ((schemaName == null) || (schemaName.isEmpty()))
+        {
+            this.schemaNameWithSeperator = "";
+        } else {
+            this.schemaNameWithSeperator = schemaName + ".";
+        }
     }
 
     @Override
@@ -44,11 +56,11 @@ public class Sequence implements SchemaEntity {
 
     @Override
     public String ddl() {
-        return dialect.constraints().createSequence(name);
+        return dialect.constraints().createSequence(schemaNameWithSeperator+name);
     }
 
     @Override
     public String dropDDL() {
-        return "DROP SEQUENCE " + name;
+        return "DROP SEQUENCE " + schemaNameWithSeperator+name;
     }
 }

--- a/src/main/java/org/polyjdbc/core/schema/model/Sequence.java
+++ b/src/main/java/org/polyjdbc/core/schema/model/Sequence.java
@@ -27,7 +27,7 @@ public class Sequence implements SchemaEntity {
 
     private final Dialect dialect;
 
-    private String schemaNameWithSeperator;
+    private String schemaNameWithSeparator;
 
     public Sequence(Dialect dialect, String name) {
         this(dialect, name, "");
@@ -36,10 +36,10 @@ public class Sequence implements SchemaEntity {
     public Sequence(Dialect dialect, String name, String schemaName) {
         this.name = name;
         this.dialect = dialect;
-        if ((schemaName == null) || (schemaName.isEmpty())) {
-            this.schemaNameWithSeperator = "";
+        if (schemaName == null || schemaName.isEmpty()) {
+            this.schemaNameWithSeparator = "";
         } else {
-            this.schemaNameWithSeperator = schemaName + ".";
+            this.schemaNameWithSeparator = schemaName + ".";
         }
     }
 
@@ -55,11 +55,11 @@ public class Sequence implements SchemaEntity {
 
     @Override
     public String ddl() {
-        return dialect.constraints().createSequence(schemaNameWithSeperator+name);
+        return dialect.constraints().createSequence(schemaNameWithSeparator+name);
     }
 
     @Override
     public String dropDDL() {
-        return "DROP SEQUENCE " + schemaNameWithSeperator+name;
+        return "DROP SEQUENCE " + schemaNameWithSeparator+name;
     }
 }

--- a/src/main/java/org/polyjdbc/core/schema/model/SequenceBuilder.java
+++ b/src/main/java/org/polyjdbc/core/schema/model/SequenceBuilder.java
@@ -30,8 +30,17 @@ public final class SequenceBuilder {
         this.sequence = new Sequence(schema.getDialect(), name);
     }
 
+    private SequenceBuilder(Schema schema, String name, String schemaName) {
+        this.schema = schema;
+        this.sequence = new Sequence(schema.getDialect(), name, schemaName);
+    }
+
     public static SequenceBuilder sequence(Schema schema, String name) {
         return new SequenceBuilder(schema, name);
+    }
+
+    public static SequenceBuilder sequence(Schema schema, String name, String schemaName) {
+        return new SequenceBuilder(schema, name, schemaName);
     }
 
     public Sequence build() {

--- a/src/test/java/org/polyjdbc/core/infrastructure/PolyDatabaseTest.java
+++ b/src/test/java/org/polyjdbc/core/infrastructure/PolyDatabaseTest.java
@@ -64,23 +64,19 @@ public abstract class PolyDatabaseTest {
         return transactionManager.openTransaction();
     }
 
-    protected void setDataSource(DataSource dataSource)
-    {
+    protected void setDataSource(DataSource dataSource) {
         this.dataSource = dataSource;
     }
 
-    protected void setPolyJDBC(PolyJDBC polyJDBC)
-    {
+    protected void setPolyJDBC(PolyJDBC polyJDBC) {
         this.polyJDBC = polyJDBC;
     }
 
-    protected void setTransactionManager(TransactionManager transactionManager)
-    {
+    protected void setTransactionManager(TransactionManager transactionManager) {
         this.transactionManager = transactionManager;
     }
 
-    protected void setCleaner(TheCleaner cleaner)
-    {
+    protected void setCleaner(TheCleaner cleaner) {
         this.cleaner = cleaner;
     }
 

--- a/src/test/java/org/polyjdbc/core/infrastructure/PolyDatabaseTest.java
+++ b/src/test/java/org/polyjdbc/core/infrastructure/PolyDatabaseTest.java
@@ -64,6 +64,26 @@ public abstract class PolyDatabaseTest {
         return transactionManager.openTransaction();
     }
 
+    protected void setDataSource(DataSource dataSource)
+    {
+        this.dataSource = dataSource;
+    }
+
+    protected void setPolyJDBC(PolyJDBC polyJDBC)
+    {
+        this.polyJDBC = polyJDBC;
+    }
+
+    protected void setTransactionManager(TransactionManager transactionManager)
+    {
+        this.transactionManager = transactionManager;
+    }
+
+    protected void setCleaner(TheCleaner cleaner)
+    {
+        this.cleaner = cleaner;
+    }
+
     protected void h2DatabaseInterface() {
         Transaction transaction = null;
         try {
@@ -76,11 +96,11 @@ public abstract class PolyDatabaseTest {
         }
     }
 
-    protected DataSource createDatabase(String dialectCode, String jdbcUrl, String user, String password) throws Exception {
+    protected DataSource createDatabase(String dialectCode, String jdbcUrl, String user, String password, String schemaName) throws Exception {
         Dialect dialect = DialectRegistry.dialect(dialectCode);
 
         this.dataSource = DataSourceFactory.create(dialect, jdbcUrl, user, password);
-        this.polyJDBC = PolyJDBCBuilder.polyJDBC(dialect).connectingToDataSource(dataSource).build();
+        this.polyJDBC = PolyJDBCBuilder.polyJDBC(dialect, schemaName).connectingToDataSource(dataSource).build();
         this.transactionManager = new DataSourceTransactionManager(dataSource);
 
         this.cleaner = new TheCleaner(polyJDBC);

--- a/src/test/java/org/polyjdbc/core/infrastructure/PolyDatabaseTest.java
+++ b/src/test/java/org/polyjdbc/core/infrastructure/PolyDatabaseTest.java
@@ -64,22 +64,6 @@ public abstract class PolyDatabaseTest {
         return transactionManager.openTransaction();
     }
 
-    protected void setDataSource(DataSource dataSource) {
-        this.dataSource = dataSource;
-    }
-
-    protected void setPolyJDBC(PolyJDBC polyJDBC) {
-        this.polyJDBC = polyJDBC;
-    }
-
-    protected void setTransactionManager(TransactionManager transactionManager) {
-        this.transactionManager = transactionManager;
-    }
-
-    protected void setCleaner(TheCleaner cleaner) {
-        this.cleaner = cleaner;
-    }
-
     protected void h2DatabaseInterface() {
         Transaction transaction = null;
         try {

--- a/src/test/java/org/polyjdbc/core/integration/DatabaseTest.java
+++ b/src/test/java/org/polyjdbc/core/integration/DatabaseTest.java
@@ -33,8 +33,7 @@ public class DatabaseTest extends PolyDatabaseTest {
                               @Optional("jdbc:h2:mem:test") String url,
                               @Optional("polly") String user,
                               @Optional("polly") String password,
-                              @Optional String schemaName) throws Exception
-    {
+                              @Optional String schemaName) throws Exception {
         logger.info("staring tests with "+dialectCode+" database ...");
 
         super.createDatabase(dialectCode, url, user, password, schemaName);

--- a/src/test/java/org/polyjdbc/core/integration/DatabaseTest.java
+++ b/src/test/java/org/polyjdbc/core/integration/DatabaseTest.java
@@ -25,20 +25,21 @@ import java.util.Arrays;
 public class DatabaseTest extends PolyDatabaseTest {
     private static final org.slf4j.Logger logger = LoggerFactory.getLogger(DatabaseTest.class);
 
-    private TestSchemaManager schemaManager;
+    protected TestSchemaManager schemaManager;
     
-    @Parameters({"dialect", "url", "user", "password"})
+    @Parameters({"dialect", "url", "user", "password", "schemaName"})
     @BeforeClass(alwaysRun = true)
     public void setUpDatabase(@Optional("H2") String dialectCode,
                               @Optional("jdbc:h2:mem:test") String url,
                               @Optional("polly") String user,
-                              @Optional("polly") String password) throws Exception
+                              @Optional("polly") String password,
+                              @Optional String schemaName) throws Exception
     {
         logger.info("staring tests with "+dialectCode+" database ...");
 
-        super.createDatabase(dialectCode, url, user, password);
+        super.createDatabase(dialectCode, url, user, password, schemaName);
 
-        this.schemaManager = new TestSchemaManager(polyJDBC());
+        this.schemaManager = new TestSchemaManager(polyJDBC(), schemaName);
         schemaManager.createSchema();
     }
 

--- a/src/test/java/org/polyjdbc/core/integration/TestSchemaManager.java
+++ b/src/test/java/org/polyjdbc/core/integration/TestSchemaManager.java
@@ -25,12 +25,19 @@ public class TestSchemaManager {
 
     private Schema schema;
 
-    public TestSchemaManager(PolyJDBC polyJDBC) {
+    private String schemaName;
+
+    public TestSchemaManager(PolyJDBC polyJDBC, String schemaName) {
         this.polyJDBC = polyJDBC;
+        this.schemaName = schemaName;
     }
 
     public void createSchema() {
-        schema = new Schema(polyJDBC.dialect());
+        if (schemaName == null) {
+            schema = new Schema(polyJDBC.dialect());
+        } else {
+            schema = new Schema(polyJDBC.dialect(), schemaName);
+        }
 
         schema.addRelation("test")
                 .withAttribute().longAttr("id").withAdditionalModifiers("AUTO_INCREMENT").and()

--- a/src/test/java/org/polyjdbc/core/integration/TestSchemaManager.java
+++ b/src/test/java/org/polyjdbc/core/integration/TestSchemaManager.java
@@ -33,11 +33,8 @@ public class TestSchemaManager {
     }
 
     public void createSchema() {
-        if (schemaName == null) {
-            schema = new Schema(polyJDBC.dialect());
-        } else {
-            schema = new Schema(polyJDBC.dialect(), schemaName);
-        }
+        schema = new Schema(polyJDBC.dialect(), schemaName);
+
 
         schema.addRelation("test")
                 .withAttribute().longAttr("id").withAdditionalModifiers("AUTO_INCREMENT").and()

--- a/src/test/java/org/polyjdbc/core/schema/SchemaInspectorImplTest.java
+++ b/src/test/java/org/polyjdbc/core/schema/SchemaInspectorImplTest.java
@@ -29,6 +29,7 @@ public class SchemaInspectorImplTest extends DatabaseTest {
 
     @Test
     public void shouldReturnTrueWhenRelationExists() {
+
         // given
         SchemaInspector inspector = new SchemaInspectorImpl(transaction());
 

--- a/src/test/java/org/polyjdbc/core/transaction/UnmanagedTransactionTest.java
+++ b/src/test/java/org/polyjdbc/core/transaction/UnmanagedTransactionTest.java
@@ -38,7 +38,7 @@ public class UnmanagedTransactionTest {
     public void setUpDatabase() {
         dataSource = DataSourceFactory.create(dialect, "jdbc:h2:mem:unmanaged_test", "polly", "polly");
         polyJDBC = PolyJDBCBuilder.polyJDBC(dialect).connectingToDataSource(dataSource).build();
-        new TestSchemaManager(polyJDBC).createSchema();
+        new TestSchemaManager(polyJDBC, null).createSchema();
     }
 
     @BeforeMethod

--- a/src/test/resources/testng-integration.xml
+++ b/src/test/resources/testng-integration.xml
@@ -19,6 +19,24 @@
         </packages>
     </test>
 
+    <test name="postgres-with-schema">
+        <groups>
+            <run>
+                <include name="integration"/>
+            </run>
+        </groups>
+
+        <parameter name="dialect" value="POSTGRES"/>
+        <parameter name="url" value="jdbc:postgresql://localhost:5432/polly"/>
+        <parameter name="user" value="polly"/>
+        <parameter name="password" value="polly"/>
+        <parameter name="schemaName" value="public"/>
+
+        <packages>
+            <package name="org.polyjdbc.core.*"/>
+        </packages>
+    </test>
+
     <test name="mysql">
         <groups>
             <run>
@@ -30,6 +48,24 @@
         <parameter name="url" value="jdbc:mysql://localhost/polly"/>
         <parameter name="user" value="polly"/>
         <parameter name="password" value="polly"/>
+
+        <packages>
+            <package name="org.polyjdbc.core.*"/>
+        </packages>
+    </test>
+
+    <test name="mysql-with-schema">
+        <groups>
+            <run>
+                <include name="integration"/>
+            </run>
+        </groups>
+
+        <parameter name="dialect" value="MYSQL"/>
+        <parameter name="url" value="jdbc:mysql://localhost/polly"/>
+        <parameter name="user" value="polly"/>
+        <parameter name="password" value="polly"/>
+        <parameter name="schemaName" value="polly"/>
 
         <packages>
             <package name="org.polyjdbc.core.*"/>

--- a/src/test/resources/testng.xml
+++ b/src/test/resources/testng.xml
@@ -6,4 +6,18 @@
             <package name="org.polyjdbc.core.*"/>
         </packages>
     </test>
+
+    <test name="h2-with-schema">
+        <groups>
+            <run>
+                <include name="integration"/>
+            </run>
+        </groups>
+
+        <parameter name="schemaName" value="public"/>
+
+        <packages>
+            <package name="org.polyjdbc.core.*"/>
+        </packages>
+    </test>
 </suite>


### PR DESCRIPTION
Added schema name support to enable users to define their own schemas. 

Example of use:
```
PolyJDBC polyJDBC = PolyJDBCBuilder.polyJDBC(dialectName.getPolyDialect(), "my_schema")
                .usingManagedConnections(...)
                .build();
```

Note that queries are not schema aware and they rely on the user to add the schema to the table name when querying a table. Example: query sent to polyjdbc should be "Select * from **my_schema**.table1;"
Added tests configuration for integration tests.