### PR TITLE
Fixing max string type for mssql

### DIFF
--- a/src/main/java/org/polyjdbc/core/dialect/MsSqlDialectTypes.java
+++ b/src/main/java/org/polyjdbc/core/dialect/MsSqlDialectTypes.java
@@ -30,4 +30,9 @@ public class MsSqlDialectTypes extends DefaultDialectTypes {
     public String timestamp() {
         return "DATETIME";
     }
+
+    @Override
+    public String text() {
+        return "VARCHAR(MAX)";
+    }
 }


### PR DESCRIPTION
Adding text override for mssql since the max type should be VARCHAR(MAX) rather than TEXT

This PR references Issue https://github.com/polyjdbc/polyjdbc/issues/26