### PR TITLE
TheCloser does not close it all

### DIFF
--- a/src/main/java/org/polyjdbc/core/util/TheCloser.java
+++ b/src/main/java/org/polyjdbc/core/util/TheCloser.java
@@ -29,14 +29,14 @@ public final class TheCloser {
     }
 
     public static void close(Closeable... toClose) {
-        try {
-            for (Closeable closeable : toClose) {
-                if (closeable != null) {
+        for (Closeable closeable : toClose) {
+            if (closeable != null) {
+                try {
                     closeable.close();
+                } catch (IOException exception) {
+                    logger.warn("Failed to close resource", exception);
                 }
             }
-        } catch (IOException exception) {
-            logger.warn("Failed to close resource", exception);
         }
     }
 

--- a/src/test/java/org/polyjdbc/core/util/TheCloserTest.java
+++ b/src/test/java/org/polyjdbc/core/util/TheCloserTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017 Björn Raupach.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.polyjdbc.core.util;
+
+import java.io.Closeable;
+import java.io.IOException;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ *
+ * @author Björn Raupach
+ */
+public class TheCloserTest {
+    
+    @Test
+    public void theCloserShouldTryToCloseItAll() {
+        CloseableMock c1 = new CloseableMock(true);
+        CloseableMock c2 = new CloseableMock(false);
+        
+        TheCloser.close(c1, c2);
+        
+        Assert.assertTrue(c2.isClosed());
+    }
+    
+    static class CloseableMock implements Closeable {
+        
+        private final boolean throwException;
+        private boolean isClosed;
+        
+        public CloseableMock(boolean throwException) {
+            this.throwException = throwException;
+        }
+
+        public boolean isClosed() {
+            return isClosed;
+        }
+
+        @Override
+        public void close() throws IOException {
+            if (throwException) {
+                throw new IOException();
+            }
+            isClosed = true;
+        }
+    }
+    
+}


### PR DESCRIPTION
Minor issue. The TheCloser.close is varargs. If one of the Closeables throws an IOException, the following ones aren't closed.

Attached a TestCase.