### PR TITLE
fixed bug in SchemaInspector

### DIFF
--- a/src/main/java/org/polyjdbc/core/schema/SchemaInspectorImpl.java
+++ b/src/main/java/org/polyjdbc/core/schema/SchemaInspectorImpl.java
@@ -71,7 +71,17 @@ class SchemaInspectorImpl implements SchemaInspector {
             ResultSet resultSet = metadata.getTables(catalog, schemaName, convertCase(name), new String[]{"TABLE"});
             transaction.registerCursor(resultSet);
 
-            return resultSet.next();
+            if (schemaName != null) {
+                return resultSet.next();
+            } else {
+                while (resultSet.next()) {
+                    String tableSchemaName = resultSet.getString("TABLE_SCHEM");
+                    return tableSchemaName.equals("public") ||
+                           tableSchemaName.equals("") ||
+                           tableSchemaName == null;
+                }
+                return false;
+            }
         } catch (SQLException exception) {
             throw new SchemaInspectionException("RELATION_LOOKUP_ERROR", "Failed to obtain relation list when looking for relation " + name, exception);
         }

--- a/src/main/java/org/polyjdbc/core/schema/SchemaInspectorImpl.java
+++ b/src/main/java/org/polyjdbc/core/schema/SchemaInspectorImpl.java
@@ -76,9 +76,9 @@ class SchemaInspectorImpl implements SchemaInspector {
             } else {
                 while (resultSet.next()) {
                     String tableSchemaName = resultSet.getString("TABLE_SCHEM");
-                    return tableSchemaName.equalsIgnoreCase("public") ||
-                           tableSchemaName.equals("") ||
-                           tableSchemaName == null;
+                    return tableSchemaName == null ||
+                           tableSchemaName.equalsIgnoreCase("public") ||
+                           tableSchemaName.equals("");
                 }
                 return false;
             }

--- a/src/main/java/org/polyjdbc/core/schema/SchemaInspectorImpl.java
+++ b/src/main/java/org/polyjdbc/core/schema/SchemaInspectorImpl.java
@@ -76,7 +76,7 @@ class SchemaInspectorImpl implements SchemaInspector {
             } else {
                 while (resultSet.next()) {
                     String tableSchemaName = resultSet.getString("TABLE_SCHEM");
-                    return tableSchemaName.equals("public") ||
+                    return tableSchemaName.equalsIgnoreCase("public") ||
                            tableSchemaName.equals("") ||
                            tableSchemaName == null;
                 }


### PR DESCRIPTION
When checking if a table exists in public schema, SchemaInspector returns true if this table not exists in public but exists in any named schema.

See `schemaPattern` param https://docs.oracle.com/javase/8/docs/api/java/sql/DatabaseMetaData.html#getTables-java.lang.String-java.lang.String-java.lang.String-java.lang.String:A-